### PR TITLE
Homomorphic encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options:
   --save-anyway                Saves output of devirtualizer even if it fails [default: False]
   --only-save-devirted         Only saves successfully devirtualized methods (This option only matters if you use the save anyway option) [default: False]
   --require-deps-for-generics  Require dependencies when resolving generic methods for accuracy [default: True]
+  --hm-pass <spec>             Homomorphic password(s) keyed by mdtoken, repeatable. Formats: mdtoken:order:type:value | mdtoken:type:value. Types: sbyte, byte, short, ushort, int, uint, long, ulong, string. Strings use UTF-16. Passwords are consumed per method in specified order.
   --version                    Show version information
   -?, -h, --help               Show help and usage information
 ```
@@ -42,6 +43,29 @@ Options:
 ```console
 $ EazyDevirt.exe test.exe -v 3 --preserve-all --save-anyway true
 ```
+
+### Homomorphic Encryption passwords (--hm-pass)
+- Provide one or more passwords per method using the metadata token (hex, with or without `0x`).
+- Typed-only: you must specify the type. Supported: `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `string`.
+- Repeat the option for multiple passwords. Use optional 1-based `order` to control sequence when a method has multiple Homomorphic Encryption blocks.
+
+Formats (typed-only):
+- `mdtoken:order:type:value`
+- `mdtoken:type:value`
+
+Examples:
+```console
+# Two explicitly ordered numeric passwords for method 0x06000123
+EazyDevirt.exe app.exe --hm-pass 0x06000123:1:uint:1234 --hm-pass 0x06000123:2:ulong:0xDEADBEEF
+
+# Multiple methods; string uses UTF-16
+EazyDevirt.exe app.exe \
+  --hm-pass 06000123:int:1337 \
+  --hm-pass 06000456:string:MySecret
+```
+
+It should be noted there are two additional password types that are not supported by [EazyDevirt]: `IEnumerable` and `byte[]`.
+Feel free to make a PR if you need support for them.
 
 ### Notes
 Don't rename any members before devirtualization, as [Eazfuscator.NET] resolves members using names rather than tokens.

--- a/src/EazyDevirt/Core/Architecture/VMMethod.cs
+++ b/src/EazyDevirt/Core/Architecture/VMMethod.cs
@@ -20,20 +20,16 @@ internal record VMMethod(MethodDefinition Parent, string EncodedMethodKey, long 
     public bool SuccessfullyDevirtualized { get; set; }
     public bool HasHomomorphicEncryption { get; set; }
     public int CodeSize { get; set; }
-    public int CurrentVirtualOffset { get; set; }
+    public uint CurrentVirtualOffset { get; set; }
     /// <summary>
-    /// For each instruction index, stores the VM "virtual offset" captured at decode-time.
-    /// </summary>
-    public List<uint> InstructionVirtualOffsets { get; set; }
-    /// <summary>
-    /// Mapping from VM virtual offset to CIL offset, built once during decoding.
+    /// Mapping from VM virtual offset to CIL offset, built once during instruction reading.
     /// </summary>
     public Dictionary<uint, int> VmToCilOffsetMap { get; set; }
     public long InitialCodeStreamPosition { get; set; }
     /// <summary>
     /// Stack holding Homomorphic Encryption ending positions. Used to calculate virtual <-> CIL offsets.
     /// </summary>
-    public Stack<int> HMEndPositionStack { get; set; }
+    public Stack<uint> HMEndPositionStack { get; set; }
     
     public override string ToString() =>
         $"Parent: {Parent.MetadataToken} | EncodedMethodKey: {EncodedMethodKey} | MethodKey: 0x{MethodKey:X} | " +

--- a/src/EazyDevirt/Core/Architecture/VMMethod.cs
+++ b/src/EazyDevirt/Core/Architecture/VMMethod.cs
@@ -1,4 +1,4 @@
-﻿using AsmResolver.DotNet;
+using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.PE.DotNet.Cil;
 
@@ -17,12 +17,23 @@ internal record VMMethod(MethodDefinition Parent, string EncodedMethodKey, long 
     public List<CilLocalVariable> Locals { get; set; }
     public List<CilInstruction> Instructions { get; set; }
     
-    
     public bool SuccessfullyDevirtualized { get; set; }
     public bool HasHomomorphicEncryption { get; set; }
     public int CodeSize { get; set; }
-    public long CodePosition { get; set; }
+    public int CurrentVirtualOffset { get; set; }
+    /// <summary>
+    /// For each instruction index, stores the VM "virtual offset" captured at decode-time.
+    /// </summary>
+    public List<uint> InstructionVirtualOffsets { get; set; }
+    /// <summary>
+    /// Mapping from VM virtual offset to CIL offset, built once during decoding.
+    /// </summary>
+    public Dictionary<uint, int> VmToCilOffsetMap { get; set; }
     public long InitialCodeStreamPosition { get; set; }
+    /// <summary>
+    /// Stack holding Homomorphic Encryption ending positions. Used to calculate virtual <-> CIL offsets.
+    /// </summary>
+    public Stack<int> HMEndPositionStack { get; set; }
     
     public override string ToString() =>
         $"Parent: {Parent.MetadataToken} | EncodedMethodKey: {EncodedMethodKey} | MethodKey: 0x{MethodKey:X} | " +

--- a/src/EazyDevirt/Core/Crypto/HMDecryptionChain.cs
+++ b/src/EazyDevirt/Core/Crypto/HMDecryptionChain.cs
@@ -15,7 +15,7 @@ internal abstract class HMDecryptionChain
     {
         var pbkdf = new PBKDF2(password, salt, 1);
         var array = new SymmetricAlgorithm[5];
-        for (int i = 0; i < 5; i++)
+        for (var i = 0; i < 5; i++)
         {
             var chain = new SymmetricAlgorithmChain(new Skip32Cipher());
             chain.Key = pbkdf.GetBytes(chain.KeySize / 8);

--- a/src/EazyDevirt/Core/Crypto/HMDecryptionChain.cs
+++ b/src/EazyDevirt/Core/Crypto/HMDecryptionChain.cs
@@ -2,16 +2,16 @@ using System.Security.Cryptography;
 
 namespace EazyDevirt.Core.Crypto;
 
-internal abstract class HMEncryptionChain
+internal abstract class HMDecryptionChain
 {
     private readonly SymmetricAlgorithm[] _algorithmChains;
 
-    protected HMEncryptionChain(byte[] password, long salt)
+    protected HMDecryptionChain(byte[] password, long salt)
         : this(password, ConvertLongToLittleEndian(salt))
     {
     }
 
-    protected HMEncryptionChain(byte[] password, byte[] salt)
+    protected HMDecryptionChain(byte[] password, byte[] salt)
     {
         var pbkdf = new PBKDF2(password, salt, 1);
         var array = new SymmetricAlgorithm[5];

--- a/src/EazyDevirt/Core/Crypto/HMDecryptor.cs
+++ b/src/EazyDevirt/Core/Crypto/HMDecryptor.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace EazyDevirt.Core.Crypto;
 
-internal sealed class HMDecryptor : HMEncryptionChain
+internal sealed class HMDecryptor : HMDecryptionChain
 {
     public HMDecryptor(byte[] password, long salt) : base(password, salt)
     {

--- a/src/EazyDevirt/Core/Crypto/HMDecryptor.cs
+++ b/src/EazyDevirt/Core/Crypto/HMDecryptor.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-
 namespace EazyDevirt.Core.Crypto;
 
 internal sealed class HMDecryptor : HMDecryptionChain

--- a/src/EazyDevirt/Core/Crypto/HMDecryptor.cs
+++ b/src/EazyDevirt/Core/Crypto/HMDecryptor.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+
+namespace EazyDevirt.Core.Crypto;
+
+internal sealed class HMDecryptor : HMEncryptionChain
+{
+    public HMDecryptor(byte[] password, long salt) : base(password, salt)
+    {
+    }
+
+    public byte[] DecryptInstructionBlock(Stream instructionsStream)
+    {
+        // Read first 4 bytes (encrypted header containing original length)
+        var header = new byte[4];
+        ReadBytes(instructionsStream, header, 0, 4);
+
+        // Decrypt header to obtain original size
+        var decryptedHeader = DecryptBytes(header, startWithEncrypt: false);
+        var originalSize = ConvertInt32BytesToLittleEndian(decryptedHeader, 0);
+
+        // Total encrypted size is aligned to 4 and includes 4-byte header
+        var alignedTotal = MinAlignToMultipleOf4(originalSize);
+        var remaining = alignedTotal - 4;
+
+        var fullBlock = new byte[alignedTotal];
+        Buffer.BlockCopy(header, 0, fullBlock, 0, 4);
+
+        // Read remaining encrypted bytes
+        ReadBytes(instructionsStream, fullBlock, 4, remaining);
+
+        // Decrypt full block then strip 4-byte header
+        var decrypted = DecryptBytes(fullBlock, startWithEncrypt: false);
+        var result = new byte[originalSize];
+        Buffer.BlockCopy(decrypted, 4, result, 0, originalSize);
+        return result;
+    }
+
+    private static void ReadBytes(Stream stream, byte[] buffer, int offset, int count)
+    {
+        var remaining = count;
+        while (remaining > 0)
+        {
+            var read = stream.Read(buffer, offset, remaining);
+            if (read <= 0)
+                throw new EndOfStreamException("Unexpected end of stream while reading encrypted homomorphic block.");
+            offset += read;
+            remaining -= read;
+        }
+    }
+}

--- a/src/EazyDevirt/Core/Crypto/HMEncryptionChain.cs
+++ b/src/EazyDevirt/Core/Crypto/HMEncryptionChain.cs
@@ -1,0 +1,108 @@
+using System.Security.Cryptography;
+
+namespace EazyDevirt.Core.Crypto;
+
+internal abstract class HMEncryptionChain
+{
+    private readonly SymmetricAlgorithm[] _algorithmChains;
+
+    protected HMEncryptionChain(byte[] password, long salt)
+        : this(password, ConvertLongToLittleEndian(salt))
+    {
+    }
+
+    protected HMEncryptionChain(byte[] password, byte[] salt)
+    {
+        var pbkdf = new PBKDF2(password, salt, 1);
+        var array = new SymmetricAlgorithm[5];
+        for (int i = 0; i < 5; i++)
+        {
+            var chain = new SymmetricAlgorithmChain(new Skip32Cipher());
+            chain.Key = pbkdf.GetBytes(chain.KeySize / 8);
+            chain.IV = pbkdf.GetBytes(chain.GetIVSize() / 8);
+            array[i] = chain;
+        }
+
+        _algorithmChains = array;
+    }
+
+    protected static int AlignToMultipleOf4(int value) => (value + 3) / 4 * 4;
+
+    public static int MinAlignToMultipleOf4(int value) => AlignToMultipleOf4(value + 4);
+
+    protected static byte[] ConvertLongToLittleEndian(long value)
+    {
+        var output = new byte[8];
+        ConvertLongToLittleEndian(value, output, 0);
+        return output;
+    }
+
+    protected static void ConvertLongToLittleEndian(long value, byte[] output, int startIndex)
+    {
+        output[startIndex] = (byte)value;
+        output[startIndex + 1] = (byte)(value >> 8);
+        output[startIndex + 2] = (byte)(value >> 16);
+        output[startIndex + 3] = (byte)(value >> 24);
+        output[startIndex + 4] = (byte)(value >> 32);
+        output[startIndex + 5] = (byte)(value >> 40);
+        output[startIndex + 6] = (byte)(value >> 48);
+        output[startIndex + 7] = (byte)(value >> 56);
+    }
+
+    protected static int ConvertInt32BytesToLittleEndian(byte[] bytes, int startIndex)
+    {
+        return bytes[startIndex]
+             | (bytes[startIndex + 1] << 8)
+             | (bytes[startIndex + 2] << 16)
+             | (bytes[startIndex + 3] << 24);
+    }
+
+    protected static void ConvertInt32ToLittleEndian(int value, byte[] output, int startIndex)
+    {
+        output[startIndex] = (byte)value;
+        output[startIndex + 1] = (byte)(value >> 8);
+        output[startIndex + 2] = (byte)(value >> 16);
+        output[startIndex + 3] = (byte)(value >> 24);
+    }
+
+    protected byte[] DecryptBytes(byte[] input, bool startWithEncrypt)
+    {
+        if (startWithEncrypt)
+        {
+            foreach (var alg in _algorithmChains)
+            {
+                if (startWithEncrypt)
+                {
+                    using var enc = alg.CreateEncryptor();
+                    input = enc.TransformFinalBlock(input, 0, input.Length);
+                }
+                else
+                {
+                    using var dec = alg.CreateDecryptor();
+                    input = dec.TransformFinalBlock(input, 0, input.Length);
+                }
+                startWithEncrypt = !startWithEncrypt;
+            }
+        }
+        else
+        {
+            for (int i = _algorithmChains.Length - 1; i >= 0; i--)
+            {
+                var alg = _algorithmChains[i];
+                if (startWithEncrypt)
+                {
+                    using var enc = alg.CreateEncryptor();
+                    input = enc.TransformFinalBlock(input, 0, input.Length);
+                }
+                else
+                {
+                    using var dec = alg.CreateDecryptor();
+                    input = dec.TransformFinalBlock(input, 0, input.Length);
+                }
+                startWithEncrypt = !startWithEncrypt;
+            }
+        }
+
+        return input;
+    }
+}

--- a/src/EazyDevirt/Core/Crypto/PBKDF2.cs
+++ b/src/EazyDevirt/Core/Crypto/PBKDF2.cs
@@ -1,0 +1,131 @@
+using System.Security.Cryptography;
+using System;
+
+namespace EazyDevirt.Core.Crypto;
+
+internal sealed class PBKDF2 : DeriveBytes
+{
+    private static volatile bool HasError;
+    private DeriveBytes? _derived;
+    private readonly byte[] _password;
+    private readonly byte[] _salt;
+    private readonly int _iterations;
+
+    public PBKDF2(byte[] password, byte[] salt, int iterations)
+    {
+        _password = (byte[])password.Clone();
+        _salt = (byte[])salt.Clone();
+        _iterations = iterations;
+        if (!HasError)
+        {
+            try
+            {
+                // Match sample behavior: try platform PBKDF2 (HMAC-SHA1) first.
+                _derived = new Rfc2898DeriveBytes(_password, _salt, _iterations);
+            }
+            catch
+            {
+                HasError = true;
+            }
+        }
+        if (_derived == null)
+        {
+            _derived = new PBKDF2_MD5(_password, _salt, _iterations);
+        }
+    }
+
+    public override byte[] GetBytes(int cb)
+    {
+        byte[]? result = null;
+        if (!HasError)
+        {
+            try
+            {
+                result = _derived!.GetBytes(cb);
+            }
+            catch
+            {
+                HasError = true;
+            }
+        }
+        if (result == null)
+        {
+            _derived = new PBKDF2_MD5(_password, _salt, _iterations);
+            result = _derived.GetBytes(cb);
+        }
+        return result;
+    }
+
+    public override void Reset()
+    {
+        throw new NotSupportedException();
+    }
+
+    // Fallback PBKDF2 implementation using HMAC-MD5 as PRF (mirrors decompiled sample PBKDF2-MD5).
+    private sealed class PBKDF2_MD5 : DeriveBytes
+    {
+        private readonly byte[] _password;
+        private readonly byte[] _salt;
+        private readonly int _iterations;
+
+        public PBKDF2_MD5(byte[] password, byte[] salt, int iterations)
+        {
+            if (password == null) throw new ArgumentNullException(nameof(password));
+            if (salt == null) throw new ArgumentNullException(nameof(salt));
+            if (iterations < 1) throw new ArgumentException("iterationCount");
+            _password = (byte[])password.Clone();
+            _salt = (byte[])salt.Clone();
+            _iterations = iterations;
+        }
+
+        public override byte[] GetBytes(int cb)
+        {
+            if (cb < 0) throw new ArgumentOutOfRangeException(nameof(cb));
+            const int dkLen = 16; // MD5 output size in bytes
+            int blocks = (cb + dkLen - 1) / dkLen;
+            byte[] output = new byte[blocks * dkLen];
+            int offset = 0;
+
+            for (int i = 1; i <= blocks; i++)
+            {
+                byte[] t = F(_password, _salt, _iterations, i);
+                Buffer.BlockCopy(t, 0, output, offset, dkLen);
+                offset += dkLen;
+            }
+
+            if (cb < output.Length)
+            {
+                byte[] truncated = new byte[cb];
+                Buffer.BlockCopy(output, 0, truncated, 0, cb);
+                return truncated;
+            }
+            return output;
+        }
+
+        private static byte[] F(byte[] P, byte[] S, int c, int blockIndex)
+        {
+            using var hmac = new HMACMD5(P);
+            var saltBlock = new byte[S.Length + 4];
+            Buffer.BlockCopy(S, 0, saltBlock, 0, S.Length);
+            // PBKDF2 uses big-endian block index
+            saltBlock[S.Length] = (byte)(blockIndex >> 24);
+            saltBlock[S.Length + 1] = (byte)(blockIndex >> 16);
+            saltBlock[S.Length + 2] = (byte)(blockIndex >> 8);
+            saltBlock[S.Length + 3] = (byte)blockIndex;
+            byte[] u = hmac.ComputeHash(saltBlock);
+            byte[] t = (byte[])u.Clone();
+            for (int j = 2; j <= c; j++)
+            {
+                u = hmac.ComputeHash(u);
+                for (int k = 0; k < t.Length; k++)
+                    t[k] ^= u[k];
+            }
+            return t;
+        }
+
+        public override void Reset()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/EazyDevirt/Core/Crypto/Skip32Cipher.cs
+++ b/src/EazyDevirt/Core/Crypto/Skip32Cipher.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Security.Cryptography;
+
+namespace EazyDevirt.Core.Crypto;
+
+internal sealed class Skip32Cipher : SymmetricAlgorithm
+{
+    private sealed class Skip32 : IDisposable, ICryptoTransform
+    {
+        private readonly byte[] _key;
+        private readonly bool _isEncrypt;
+
+        public int InputBlockSize => 4;
+        public int OutputBlockSize => 4;
+        public bool CanTransformMultipleBlocks => true;
+        public bool CanReuseTransform => true;
+
+        public Skip32(byte[] key, bool isEncrypt)
+        {
+            _key = key;
+            _isEncrypt = isEncrypt;
+        }
+
+        public void Dispose() { }
+
+        public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+        {
+            if (inputCount % 4 != 0)
+                throw new ArgumentOutOfRangeException(nameof(inputCount), "Input count must be multiple of 4.");
+            for (int i = 0; i < inputCount; i += 4)
+                TransformOne(_key, inputBuffer, inputOffset + i, outputBuffer, outputOffset + i, _isEncrypt);
+            return inputCount;
+        }
+
+        public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        {
+            var output = new byte[inputCount];
+            TransformBlock(inputBuffer, inputOffset, inputCount, output, 0);
+            return output;
+        }
+    }
+
+    private static readonly byte[] F = new byte[256]
+    {
+        163,215,9,131,248,72,246,244,179,33,21,120,153,177,175,249,231,45,77,138,
+        206,76,202,46,82,149,217,30,78,56,68,40,10,223,2,160,23,241,96,104,18,183,122,195,233,250,
+        61,83,150,132,107,186,242,99,154,25,124,174,229,245,247,22,106,162,57,182,123,15,193,147,
+        129,27,238,180,26,234,208,145,47,184,85,185,218,133,63,65,191,224,90,88,128,95,102,11,216,144,
+        53,213,192,167,51,6,101,105,69,0,148,86,109,152,155,118,151,252,178,194,176,254,219,32,
+        225,235,214,228,221,71,74,29,66,237,158,110,73,60,205,67,39,210,7,212,222,199,103,24,137,203,
+        48,31,141,198,143,170,200,116,220,201,93,92,49,164,112,136,97,44,159,13,43,135,80,130,84,100,
+        38,125,3,64,52,75,28,115,209,196,253,59,204,251,127,171,230,62,91,165,173,4,35,156,20,81,34,240,
+        41,121,113,126,255,140,14,226,12,239,188,114,117,111,55,161,236,211,142,98,139,134,16,232,8,119,
+        17,190,146,79,36,197,50,54,157,207,243,166,187,172,94,108,169,19,87,37,181,227,189,168,58,1,5,89,42,70
+    };
+
+    public Skip32Cipher()
+    {
+        LegalBlockSizesValue = new[] { new KeySizes(32, 32, 0) };
+        LegalKeySizesValue = new[] { new KeySizes(80, 80, 0) };
+        BlockSizeValue = 32;
+        KeySizeValue = 80;
+        ModeValue = CipherMode.ECB;
+        PaddingValue = PaddingMode.None;
+    }
+
+    public Skip32Cipher(byte[] key) : this()
+    {
+        Key = key ?? throw new ArgumentNullException(nameof(key));
+    }
+
+    public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[]? rgbIV)
+        => new Skip32(rgbKey, false);
+
+    public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[]? rgbIV)
+        => new Skip32(rgbKey, true);
+
+    public override void GenerateIV() => throw new NotImplementedException();
+    public override void GenerateKey() => throw new NotImplementedException();
+
+    private static ushort G(byte[] key, int k, ushort w)
+    {
+        byte g1 = (byte)(w >> 8);
+        byte g2 = (byte)w;
+        byte g3 = (byte)(F[g2 ^ key[4 * k % 10]] ^ g1);
+        byte g4 = (byte)(F[g3 ^ key[(4 * k + 1) % 10]] ^ g2);
+        byte g5 = (byte)(F[g4 ^ key[(4 * k + 2) % 10]] ^ g3);
+        byte g6 = (byte)(F[g5 ^ key[(4 * k + 3) % 10]] ^ g4);
+        return (ushort)((g5 << 8) + g6);
+    }
+
+    private static void TransformOne(byte[] key, byte[] input, int start, byte[] output, int outputIndex, bool encrypt)
+    {
+        int step = encrypt ? 1 : -1;
+        int k = encrypt ? 0 : 23;
+        ushort wl = (ushort)((input[start] << 8) + input[start + 1]);
+        ushort wr = (ushort)((input[start + 2] << 8) + input[start + 3]);
+        for (int i = 0; i < 12; i++)
+        {
+            wr ^= (ushort)(G(key, k, wl) ^ k);
+            k += step;
+            wl ^= (ushort)(G(key, k, wr) ^ k);
+            k += step;
+        }
+        output[outputIndex] = (byte)(wr >> 8);
+        output[outputIndex + 1] = (byte)wr;
+        output[outputIndex + 2] = (byte)(wl >> 8);
+        output[outputIndex + 3] = (byte)wl;
+    }
+}

--- a/src/EazyDevirt/Core/Crypto/SymmetricAlgorithmChain.cs
+++ b/src/EazyDevirt/Core/Crypto/SymmetricAlgorithmChain.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Security.Cryptography;
+
+namespace EazyDevirt.Core.Crypto;
+
+internal sealed class SymmetricAlgorithmChain : SymmetricAlgorithm
+{
+    private sealed class XorTransform : IDisposable, ICryptoTransform
+    {
+        private readonly byte[] _key;
+        private readonly byte[] _iv;
+        private readonly SymmetricAlgorithm[] _algs;
+        private ICryptoTransform[]? _transforms;
+        private readonly bool _isEncryption;
+        private readonly int _blockSize;
+
+        public int InputBlockSize => _blockSize;
+        public int OutputBlockSize => _blockSize;
+        public bool CanTransformMultipleBlocks => true;
+        public bool CanReuseTransform => true;
+
+        public XorTransform(SymmetricAlgorithm[] algorithms, byte[] key, byte[] iv, bool isEncryption)
+        {
+            _key = key;
+            _iv = iv;
+            _algs = algorithms;
+            _isEncryption = isEncryption;
+            _blockSize = algorithms[^1].BlockSize / 8;
+        }
+
+        public void Dispose()
+        {
+            if (_transforms != null)
+            {
+                foreach (var t in _transforms)
+                    t?.Dispose();
+                _transforms = null;
+            }
+        }
+
+        private void EnsureTransforms()
+        {
+            if (_transforms != null) return;
+            var n = _algs.Length;
+            var arr = new ICryptoTransform[n];
+            var offset = 0;
+            for (int i = 0; i < n; i++)
+            {
+                var alg = _algs[i];
+                var keySizeBytes = alg.KeySize / 8;
+                var key = new byte[keySizeBytes];
+                Buffer.BlockCopy(_key, offset, key, 0, keySizeBytes);
+                offset += keySizeBytes;
+                var iv = new byte[alg.BlockSize / 8];
+                var t = _isEncryption ? alg.CreateEncryptor(key, iv) : alg.CreateDecryptor(key, iv);
+                arr[i] = t;
+            }
+
+            _transforms = arr;
+        }
+
+        public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        {
+            var output = new byte[inputCount];
+            TransformBlock(inputBuffer, inputOffset, inputCount, output, 0);
+            return output;
+        }
+
+        public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+        {
+            Buffer.BlockCopy(inputBuffer, inputOffset, outputBuffer, outputOffset, inputCount);
+            EnsureTransforms();
+            if (_isEncryption)
+                Encrypt(outputBuffer, outputOffset, inputCount);
+            else
+                Decrypt(outputBuffer, outputOffset, inputCount);
+            return inputCount;
+        }
+
+        private void Encrypt(byte[] buffer, int offset, int count)
+        {
+            var iv = new byte[_iv.Length];
+            Buffer.BlockCopy(_iv, 0, iv, 0, iv.Length);
+            var pos = 0;
+            foreach (var t in _transforms!)
+            {
+                var bs = t.InputBlockSize;
+                var len = (count - pos) & ~(bs - 1);
+                var end = pos + len;
+                for (int j = pos; j < end; j += bs)
+                {
+                    var p = j + offset;
+                    Xor(buffer, p, iv, 0, bs);
+                    t.TransformBlock(buffer, p, bs, buffer, p);
+                    Buffer.BlockCopy(buffer, p, iv, 0, bs);
+                }
+                pos = end;
+                if (end == count) break;
+            }
+        }
+
+        private void Decrypt(byte[] buffer, int offset, int count)
+        {
+            var iv = new byte[_iv.Length];
+            Buffer.BlockCopy(_iv, 0, iv, 0, iv.Length);
+            var tmp = new byte[iv.Length];
+            var pos = 0;
+            foreach (var t in _transforms!)
+            {
+                var bs = t.InputBlockSize;
+                var len = (count - pos) & ~(bs - 1);
+                var end = pos + len;
+                for (int j = pos; j < end; j += bs)
+                {
+                    var p = j + offset;
+                    Buffer.BlockCopy(buffer, p, tmp, 0, bs);
+                    t.TransformBlock(buffer, p, bs, buffer, p);
+                    Xor(buffer, p, iv, 0, bs);
+                    Buffer.BlockCopy(tmp, 0, iv, 0, bs);
+                }
+                pos = end;
+                if (end == count) break;
+            }
+        }
+
+        private static void Xor(byte[] buffer, int offset, byte[] iv, int ivOffset, int count)
+        {
+            for (int i = 0; i < count; i++)
+                buffer[offset + i] ^= iv[ivOffset + i];
+        }
+    }
+
+    private static class SymmetricAlgorithmComparer
+    {
+        public static int CompareBlockSize(SymmetricAlgorithm a, SymmetricAlgorithm b) => b.BlockSize.CompareTo(a.BlockSize);
+    }
+
+    private readonly SymmetricAlgorithm[] _algs;
+    private readonly int _ivSize;
+
+    public override byte[] IV
+    {
+        get => base.IV;
+        set => IVValue = (byte[])value.Clone();
+    }
+
+    public SymmetricAlgorithmChain(params SymmetricAlgorithm[] algorithms)
+    {
+        algorithms = (SymmetricAlgorithm[])algorithms.Clone();
+        Array.Sort(algorithms, SymmetricAlgorithmComparer.CompareBlockSize);
+        _algs = algorithms;
+        var totalKeyBits = 0;
+        foreach (var alg in algorithms)
+        {
+            totalKeyBits += alg.KeySize;
+            alg.Mode = CipherMode.ECB;
+            alg.Padding = PaddingMode.None;
+        }
+
+        BlockSizeValue = algorithms[^1].BlockSize;
+        LegalBlockSizesValue = new[] { new KeySizes(BlockSizeValue, BlockSizeValue, 0) };
+        KeySizeValue = totalKeyBits;
+        LegalKeySizesValue = new[] { new KeySizes(totalKeyBits, totalKeyBits, 0) };
+        _ivSize = algorithms[0].BlockSize;
+        Mode = CipherMode.ECB;
+        Padding = PaddingMode.None;
+    }
+
+    public int GetIVSize() => _ivSize;
+
+    public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) => CreateXorTransform(rgbKey, rgbIV, false);
+    public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV) => CreateXorTransform(rgbKey, rgbIV, true);
+
+    private ICryptoTransform CreateXorTransform(byte[] rgbKey, byte[] rgbIv, bool isEncryption)
+    {
+        if (rgbKey.Length * 8 != KeySize)
+            throw new ArgumentException("Invalid key size.");
+        if (rgbIv.Length * 8 != GetIVSize())
+            throw new ArgumentException("Invalid IV size.");
+        return new XorTransform(_algs, rgbKey, rgbIv, isEncryption);
+    }
+
+    public override void GenerateIV() => throw new NotSupportedException();
+    public override void GenerateKey() => throw new NotSupportedException();
+}

--- a/src/EazyDevirt/Devirtualization/Options/DevirtualizationOptions.cs
+++ b/src/EazyDevirt/Devirtualization/Options/DevirtualizationOptions.cs
@@ -1,72 +1,102 @@
-﻿namespace EazyDevirt.Devirtualization.Options;
+using System.Collections.Generic;
+
+namespace EazyDevirt.Devirtualization.Options;
 
 internal record DevirtualizationOptions
 {
 #pragma warning disable CS8618
- /// <summary>
- /// Target assembly info
- /// </summary>
- public FileInfo Assembly { get; init; }
+    /// <summary>
+    /// Target assembly info
+    /// </summary>
+    public FileInfo Assembly { get; init; }
 
- /// <summary>
- /// Path of output directory
- /// </summary>
- public DirectoryInfo OutputPath { get; init; }
+    /// <summary>
+    /// Path of output directory
+    /// </summary>
+    public DirectoryInfo OutputPath { get; init; }
 #pragma warning restore CS8618
 
- /// <summary>
- /// Verbosity level
- /// </summary>
- public int Verbosity { get; init; }
+    /// <summary>
+    /// Verbosity level
+    /// </summary>
+    public int Verbosity { get; init; }
 
- /// <summary>
- /// Shows useful debug information
- /// </summary>
- public bool Verbose => Verbosity >= 1;
+    /// <summary>
+    /// Shows useful debug information
+    /// </summary>
+    public bool Verbose => Verbosity >= 1;
 
- /// <summary>
- /// Shows more verbose information
- /// </summary>
- public bool VeryVerbose => Verbosity > 1;
+    /// <summary>
+    /// Shows more verbose information
+    /// </summary>
+    public bool VeryVerbose => Verbosity > 1;
  
- /// <summary>
- /// Shows even more verbose information
- /// </summary>
- public bool VeryVeryVerbose => Verbosity > 2;
+    /// <summary>
+    /// Shows even more verbose information
+    /// </summary>
+    public bool VeryVeryVerbose => Verbosity > 2;
  
- /// <summary>
- /// Preserves all metadata tokens
- /// </summary>
- public bool PreserveAll { get; init; }
+    /// <summary>
+    /// Preserves all metadata tokens
+    /// </summary>
+    public bool PreserveAll { get; init; }
  
- /// <summary>
- /// Don't verify labels or compute max stack for devirtualized methods
- /// </summary>
- public bool NoVerify { get; init; }
+    /// <summary>
+    /// Don't verify labels or compute max stack for devirtualized methods
+    /// </summary>
+    public bool NoVerify { get; init; }
  
- /// <summary>
- /// Keeps all obfuscator types
- /// </summary>
- public bool KeepTypes { get; init; }
+    /// <summary>
+    /// Keeps all obfuscator types
+    /// </summary>
+    public bool KeepTypes { get; init; }
  
- /// <summary>
- /// Save output even if devirtualization fails
- /// </summary>
- public bool SaveAnyway { get; init; }
+    /// <summary>
+    /// Save output even if devirtualization fails
+    /// </summary>
+    public bool SaveAnyway { get; init; }
  
- /// <summary>
- /// Only save successfully devirtualized methods
- /// </summary>
- /// <remarks>
- /// This only matters if you're using the Save Anyway option
- /// </remarks>
- public bool OnlySaveDevirted { get; init; }
+    /// <summary>
+    /// Only save successfully devirtualized methods
+    /// </summary>
+    /// <remarks>
+    /// This only matters if you're using the Save Anyway option
+    /// </remarks>
+    public bool OnlySaveDevirted { get; init; }
  
- /// <summary>
- /// Require dependencies when resolving generic methods
- /// </summary>
- /// <remarks>
- /// If this is disabled, methods utilizing generics (type or method args) may not have proper signatures if dependencies aren't able to be resolved
- /// </remarks>
- public bool RequireDepsForGenericMethods { get; init; }
+    /// <summary>
+    /// Require dependencies when resolving generic methods
+    /// </summary>
+    /// <remarks>
+    /// If this is disabled, methods utilizing generics (type or method args) may not have proper signatures if dependencies aren't able to be resolved
+    /// </remarks>
+    public bool RequireDepsForGenericMethods { get; init; }
+
+    /// <summary>
+    /// Dictionary of homomorphic encryption passwords keyed by method metadata token (mdtoken).
+    /// Provided via CLI as "--hm-pass mdtoken:type:value" (repeatable).
+    /// Types: sbyte, byte, short, ushort, int, uint, long, ulong, string.
+    /// </summary>
+    public Dictionary<uint, HmPasswordEntry> HmPasswords { get; init; } = new();
 }
+
+/// <summary>
+/// Numeric type kinds allowed for HM password values.
+/// </summary>
+internal enum NumericKind
+{
+    SByte,
+    Byte,
+    Int16,
+    UInt16,
+    Int32,
+    UInt32,
+    Int64,
+    UInt64,
+    String
+}
+
+/// <summary>
+/// Represents a typed HM password value and its precomputed big-endian bytes.
+/// </summary>
+internal sealed record HmPasswordEntry(NumericKind Kind, string Value, byte[] Bytes);

--- a/src/EazyDevirt/Devirtualization/Options/DevirtualizationOptions.cs
+++ b/src/EazyDevirt/Devirtualization/Options/DevirtualizationOptions.cs
@@ -73,11 +73,13 @@ internal record DevirtualizationOptions
     public bool RequireDepsForGenericMethods { get; init; }
 
     /// <summary>
-    /// Dictionary of homomorphic encryption passwords keyed by method metadata token (mdtoken).
-    /// Provided via CLI as "--hm-pass mdtoken:type:value" (repeatable).
+    /// Dictionary of homomorphic encryption password sequences keyed by method metadata token (mdtoken).
+    /// Provided via CLI as "--hm-pass mdtoken[:order]:type:value" (repeatable). If <c>order</c> is omitted,
+    /// passwords are appended in the order they are provided on the command line. When <c>order</c> is provided,
+    /// it is treated as a 1-based position, and passwords are consumed in ascending order per method.
     /// Types: sbyte, byte, short, ushort, int, uint, long, ulong, string.
     /// </summary>
-    public Dictionary<uint, HmPasswordEntry> HmPasswords { get; init; } = new();
+    public Dictionary<uint, List<HmPasswordEntry>> HmPasswords { get; init; } = new();
 }
 
 /// <summary>
@@ -99,4 +101,4 @@ internal enum NumericKind
 /// <summary>
 /// Represents a typed HM password value and its precomputed big-endian bytes.
 /// </summary>
-internal sealed record HmPasswordEntry(NumericKind Kind, string Value, byte[] Bytes);
+internal sealed record HmPasswordEntry(NumericKind Kind, string Value, byte[] Bytes, int Order);

--- a/src/EazyDevirt/Devirtualization/Options/DevirtualizationOptionsBinder.cs
+++ b/src/EazyDevirt/Devirtualization/Options/DevirtualizationOptionsBinder.cs
@@ -1,5 +1,8 @@
-﻿using System.CommandLine;
+using System;
+using System.CommandLine;
 using System.CommandLine.Binding;
+using System.Globalization;
+using System.Text;
 
 namespace EazyDevirt.Devirtualization.Options;
 
@@ -14,10 +17,11 @@ internal class DevirtualizationOptionsBinder : BinderBase<DevirtualizationOption
     private readonly Option<bool> _saveAnywayOption;
     private readonly Option<bool> _onlySaveDevirtedOption;
     private readonly Option<bool> _requireDepsForGenericMethods;
+    private readonly Option<string[]> _hmPasswordsOption;
 
     public DevirtualizationOptionsBinder(Argument<FileInfo> assemblyArgument, Argument<DirectoryInfo> outputPathArgument, 
         Option<int> verbosityOption, Option<bool> preserveAllOption, Option<bool> noVerifyOption, Option<bool> keepTypesOption, Option<bool> saveAnywayOption,
-        Option<bool> onlySaveDevirtedOption, Option<bool> requireDepsForGenericMethods)
+        Option<bool> onlySaveDevirtedOption, Option<bool> requireDepsForGenericMethods, Option<string[]> hmPasswordsOption)
     {
         _assemblyArgument = assemblyArgument;
         _outputPathArgument = outputPathArgument;
@@ -28,6 +32,7 @@ internal class DevirtualizationOptionsBinder : BinderBase<DevirtualizationOption
         _saveAnywayOption = saveAnywayOption;
         _onlySaveDevirtedOption = onlySaveDevirtedOption;
         _requireDepsForGenericMethods = requireDepsForGenericMethods;
+        _hmPasswordsOption = hmPasswordsOption;
     }
 
     protected override DevirtualizationOptions GetBoundValue(BindingContext bindingContext) =>
@@ -41,6 +46,265 @@ internal class DevirtualizationOptionsBinder : BinderBase<DevirtualizationOption
             KeepTypes = bindingContext.ParseResult.GetValueForOption(_keepTypesOption),
             SaveAnyway = bindingContext.ParseResult.GetValueForOption(_saveAnywayOption),
             OnlySaveDevirted = bindingContext.ParseResult.GetValueForOption(_onlySaveDevirtedOption),
-            RequireDepsForGenericMethods = bindingContext.ParseResult.GetValueForOption(_requireDepsForGenericMethods)
+            RequireDepsForGenericMethods = bindingContext.ParseResult.GetValueForOption(_requireDepsForGenericMethods),
+            HmPasswords = ParseHmPasswords(bindingContext)
         };
+
+    private Dictionary<uint, HmPasswordEntry> ParseHmPasswords(BindingContext bindingContext)
+    {
+        var dict = new Dictionary<uint, HmPasswordEntry>();
+        var entries = bindingContext.ParseResult.GetValueForOption(_hmPasswordsOption) ?? Array.Empty<string>();
+        foreach (var entry in entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+                continue;
+            // Accept formats:
+            // 1) mdtoken:type:value
+            // 2) mdtoken:value    (fallback, auto-width)
+            var parts = entry.Split(':', 3, StringSplitOptions.TrimEntries);
+            if (parts.Length < 2)
+                continue;
+
+            var tokenStr = parts[0];
+            if (!TryParseMdToken(tokenStr, out var token))
+                continue;
+
+            if (parts.Length == 3)
+            {
+                var typeStr = parts[1];
+                var valueStr = parts[2];
+                if (!TryMapType(typeStr, out var kind))
+                    continue;
+                if (!TryParseTypedNumericToBigEndian(kind, valueStr, out var bytes))
+                    continue;
+                dict[token] = new HmPasswordEntry(kind, valueStr, bytes);
+            }
+            else // parts.Length == 2 -> fallback (auto-width)
+            {
+                var valueStr = parts[1];
+                if (!TryParseNumericAutoWidthToBigEndian(valueStr, out var bytes, out var inferredKind))
+                    continue;
+                dict[token] = new HmPasswordEntry(inferredKind, valueStr, bytes);
+            }
+        }
+
+        return dict;
+    }
+
+    private static bool TryParseMdToken(string s, out uint token)
+    {
+        token = 0;
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        s = s.Trim();
+        if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            s = s[2..];
+
+        return uint.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out token);
+    }
+
+    private static bool TryMapType(string s, out NumericKind kind)
+    {
+        kind = default;
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        s = s.Trim().ToLowerInvariant();
+        switch (s)
+        {
+            case "sbyte":
+            case "i8": kind = NumericKind.SByte; return true;
+            case "byte":
+            case "u8": kind = NumericKind.Byte; return true;
+            case "short":
+            case "int16":
+            case "i16": kind = NumericKind.Int16; return true;
+            case "ushort":
+            case "uint16":
+            case "u16": kind = NumericKind.UInt16; return true;
+            case "int":
+            case "int32":
+            case "i32": kind = NumericKind.Int32; return true;
+            case "uint":
+            case "uint32":
+            case "u32": kind = NumericKind.UInt32; return true;
+            case "long":
+            case "int64":
+            case "i64": kind = NumericKind.Int64; return true;
+            case "ulong":
+            case "uint64":
+            case "u64": kind = NumericKind.UInt64; return true;
+            case "string":
+            case "str": kind = NumericKind.String; return true;
+            default: return false;
+        }
+    }
+
+    private static bool TryParseTypedNumericToBigEndian(NumericKind kind, string s, out byte[] bytes)
+    {
+        bytes = Array.Empty<byte>();
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        s = s.Trim();
+        if (kind == NumericKind.String)
+        {
+            bytes = Encoding.Unicode.GetBytes(s);
+            return true;
+        }
+
+        bool isHex = s.StartsWith("0x", StringComparison.OrdinalIgnoreCase);
+        if (isHex)
+        {
+            var hex = s[2..];
+            if (!ulong.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var u))
+                return false;
+            switch (kind)
+            {
+                case NumericKind.SByte:
+                {
+                    var v = unchecked((sbyte)u);
+                    bytes = new[] { unchecked((byte)v) };
+                    return true;
+                }
+                case NumericKind.Byte:
+                {
+                    var v = unchecked((byte)u);
+                    bytes = new[] { v };
+                    return true;
+                }
+                case NumericKind.Int16:
+                {
+                    var v = unchecked((short)u);
+                    var uv = unchecked((ushort)v);
+                    bytes = new[] { (byte)(uv >> 8), (byte)uv };
+                    return true;
+                }
+                case NumericKind.UInt16:
+                {
+                    var v = unchecked((ushort)u);
+                    bytes = new[] { (byte)(v >> 8), (byte)v };
+                    return true;
+                }
+                case NumericKind.Int32:
+                {
+                    var v = unchecked((int)u);
+                    var uv = unchecked((uint)v);
+                    bytes = new[] { (byte)(uv >> 24), (byte)(uv >> 16), (byte)(uv >> 8), (byte)uv };
+                    return true;
+                }
+                case NumericKind.UInt32:
+                {
+                    var v = unchecked((uint)u);
+                    bytes = new[] { (byte)(v >> 24), (byte)(v >> 16), (byte)(v >> 8), (byte)v };
+                    return true;
+                }
+                case NumericKind.Int64:
+                {
+                    var v = unchecked((long)u);
+                    var uv = unchecked((ulong)v);
+                    bytes = new[]
+                    {
+                        (byte)(uv >> 56), (byte)(uv >> 48), (byte)(uv >> 40), (byte)(uv >> 32),
+                        (byte)(uv >> 24), (byte)(uv >> 16), (byte)(uv >> 8), (byte)uv
+                    };
+                    return true;
+                }
+                case NumericKind.UInt64:
+                {
+                    var v = unchecked((ulong)u);
+                    bytes = new[]
+                    {
+                        (byte)(v >> 56), (byte)(v >> 48), (byte)(v >> 40), (byte)(v >> 32),
+                        (byte)(v >> 24), (byte)(v >> 16), (byte)(v >> 8), (byte)v
+                    };
+                    return true;
+                }
+                default:
+                    return false;
+            }
+        }
+        else
+        {
+            switch (kind)
+            {
+                case NumericKind.SByte:
+                    if (!sbyte.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var sb)) return false;
+                    bytes = new[] { unchecked((byte)sb) }; return true;
+                case NumericKind.Byte:
+                    if (!byte.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var b)) return false;
+                    bytes = new[] { b }; return true;
+                case NumericKind.Int16:
+                    if (!short.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var sh)) return false;
+                    {
+                        var u = unchecked((ushort)sh);
+                        bytes = new[] { (byte)(u >> 8), (byte)u }; return true;
+                    }
+                case NumericKind.UInt16:
+                    if (!ushort.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ush)) return false;
+                    bytes = new[] { (byte)(ush >> 8), (byte)ush }; return true;
+                case NumericKind.Int32:
+                    if (!int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i32)) return false;
+                    {
+                        var u = unchecked((uint)i32);
+                        bytes = new[] { (byte)(u >> 24), (byte)(u >> 16), (byte)(u >> 8), (byte)u }; return true;
+                    }
+                case NumericKind.UInt32:
+                    if (!uint.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ui32)) return false;
+                    bytes = new[] { (byte)(ui32 >> 24), (byte)(ui32 >> 16), (byte)(ui32 >> 8), (byte)ui32 }; return true;
+                case NumericKind.Int64:
+                    if (!long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i64)) return false;
+                    {
+                        var u = unchecked((ulong)i64);
+                        bytes = new[] { (byte)(u >> 56), (byte)(u >> 48), (byte)(u >> 40), (byte)(u >> 32), (byte)(u >> 24), (byte)(u >> 16), (byte)(u >> 8), (byte)u }; return true;
+                    }
+                case NumericKind.UInt64:
+                    if (!ulong.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ui64)) return false;
+                    bytes = new[] { (byte)(ui64 >> 56), (byte)(ui64 >> 48), (byte)(ui64 >> 40), (byte)(ui64 >> 32), (byte)(ui64 >> 24), (byte)(ui64 >> 16), (byte)(ui64 >> 8), (byte)ui64 }; return true;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    private static bool TryParseNumericAutoWidthToBigEndian(string s, out byte[] bytes, out NumericKind kind)
+    {
+        bytes = Array.Empty<byte>();
+        kind = default;
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        s = s.Trim();
+
+        if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            var hex = s[2..];
+            if (!ulong.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var u))
+                return false;
+            if (u <= byte.MaxValue)
+            { bytes = new[] { (byte)u }; kind = NumericKind.Byte; return true; }
+            if (u <= ushort.MaxValue)
+            { bytes = new[] { (byte)(u >> 8), (byte)u }; kind = NumericKind.UInt16; return true; }
+            if (u <= uint.MaxValue)
+            { bytes = new[] { (byte)(u >> 24), (byte)(u >> 16), (byte)(u >> 8), (byte)u }; kind = NumericKind.UInt32; return true; }
+            bytes = new[]
+            {
+                (byte)(u >> 56), (byte)(u >> 48), (byte)(u >> 40), (byte)(u >> 32),
+                (byte)(u >> 24), (byte)(u >> 16), (byte)(u >> 8), (byte)u
+            }; kind = NumericKind.UInt64; return true;
+        }
+
+        // Decimal: try signed then unsigned to preserve width semantics
+        if (sbyte.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var sb))
+        { bytes = new[] { unchecked((byte)sb) }; kind = NumericKind.SByte; return true; }
+        if (byte.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var b))
+        { bytes = new[] { b }; kind = NumericKind.Byte; return true; }
+        if (short.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var sh))
+        { var u = unchecked((ushort)sh); bytes = new[] { (byte)(u >> 8), (byte)u }; kind = NumericKind.Int16; return true; }
+        if (ushort.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ush))
+        { bytes = new[] { (byte)(ush >> 8), (byte)ush }; kind = NumericKind.UInt16; return true; }
+        if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i32))
+        { var u = unchecked((uint)i32); bytes = new[] { (byte)(u >> 24), (byte)(u >> 16), (byte)(u >> 8), (byte)u }; kind = NumericKind.Int32; return true; }
+        if (uint.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ui32))
+        { bytes = new[] { (byte)(ui32 >> 24), (byte)(ui32 >> 16), (byte)(ui32 >> 8), (byte)ui32 }; kind = NumericKind.UInt32; return true; }
+        if (long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i64))
+        { var u = unchecked((ulong)i64); bytes = new[] { (byte)(u >> 56), (byte)(u >> 48), (byte)(u >> 40), (byte)(u >> 32), (byte)(u >> 24), (byte)(u >> 16), (byte)(u >> 8), (byte)u }; kind = NumericKind.Int64; return true; }
+        if (ulong.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ui64))
+        { bytes = new[] { (byte)(ui64 >> 56), (byte)(ui64 >> 48), (byte)(ui64 >> 40), (byte)(ui64 >> 32), (byte)(ui64 >> 24), (byte)(ui64 >> 16), (byte)(ui64 >> 8), (byte)ui64 }; kind = NumericKind.UInt64; return true; }
+
+        return false;
+    }
 }

--- a/src/EazyDevirt/Program.cs
+++ b/src/EazyDevirt/Program.cs
@@ -93,6 +93,10 @@ internal static class Program
         var requireDepsForGenerics = new Option<bool>(new[] { "--require-deps-for-generics"}, "Require dependencies when resolving generic methods for accuracy");
         requireDepsForGenerics.SetDefaultValue(true);
 
+        var hmPasswordsOption = new Option<string[]>(new[] {"--hm-pass"}, "Homomorphic password(s) keyed by mdtoken. Format: mdtoken:type:value or mdtoken:value (auto-width, may fail). Types: sbyte, byte, short, ushort, int, uint, long, ulong, string. String uses UTF-16. Repeatable.")
+        {
+            Arity = ArgumentArity.ZeroOrMore
+        };
         
         var rootCommand = new RootCommand("is an open-source tool that automatically restores the original IL code " +
                                           "from an assembly virtualized with Eazfuscator.NET")
@@ -105,13 +109,14 @@ internal static class Program
             keepTypesOption,
             saveAnywayOption,
             onlySaveDevirtedOption,
-            requireDepsForGenerics
+            requireDepsForGenerics,
+            hmPasswordsOption
         };
 
         rootCommand.SetHandler(Run,
             new DevirtualizationOptionsBinder(inputArgument, outputArgument, verbosityOption,
                 preserveAllOption, noVerifyOption, keepTypesOption, saveAnywayOption, onlySaveDevirtedOption,
-                requireDepsForGenerics));
+                requireDepsForGenerics, hmPasswordsOption));
         
         return new CommandLineBuilder(rootCommand)
             .UseDefaults()

--- a/src/EazyDevirt/Program.cs
+++ b/src/EazyDevirt/Program.cs
@@ -93,7 +93,7 @@ internal static class Program
         var requireDepsForGenerics = new Option<bool>(new[] { "--require-deps-for-generics"}, "Require dependencies when resolving generic methods for accuracy");
         requireDepsForGenerics.SetDefaultValue(true);
 
-        var hmPasswordsOption = new Option<string[]>(new[] {"--hm-pass"}, "Homomorphic password(s) keyed by mdtoken. Format: mdtoken:type:value or mdtoken:value (auto-width, may fail). Types: sbyte, byte, short, ushort, int, uint, long, ulong, string. String uses UTF-16. Repeatable.")
+        var hmPasswordsOption = new Option<string[]>(new[] {"--hm-pass"}, "Homomorphic password(s) keyed by mdtoken, supporting multiple passwords per method with optional 1-based ordering. Formats: mdtoken:order:type:value | mdtoken:type:value. Types: sbyte, byte, short, ushort, int, uint, long, ulong, string. String uses UTF-16. Repeatable; passwords are consumed in the specified order per method.")
         {
             Arity = ArgumentArity.ZeroOrMore
         };

--- a/src/EazyDevirt/Program.cs
+++ b/src/EazyDevirt/Program.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
+using System.Globalization;
 using AsmResolver.DotNet.Builder;
 using AsmResolver.DotNet.Code.Cil;
 using EazyDevirt.Devirtualization;
@@ -18,8 +19,6 @@ internal static class Program
         var parser = BuildParser();
 
         await parser.InvokeAsync(args).ConfigureAwait(false);
-
-        Console.ReadLine();
     }
 
     private static void Run(DevirtualizationOptions options)
@@ -93,10 +92,165 @@ internal static class Program
         var requireDepsForGenerics = new Option<bool>(new[] { "--require-deps-for-generics"}, "Require dependencies when resolving generic methods for accuracy");
         requireDepsForGenerics.SetDefaultValue(true);
 
-        var hmPasswordsOption = new Option<string[]>(new[] {"--hm-pass"}, "Homomorphic password(s) keyed by mdtoken, supporting multiple passwords per method with optional 1-based ordering. Formats: mdtoken:order:type:value | mdtoken:type:value. Types: sbyte, byte, short, ushort, int, uint, long, ulong, string. String uses UTF-16. Repeatable; passwords are consumed in the specified order per method.")
+        var hmPasswordsOption = new Option<string[]>(new[] {"--hm-pass"}, "Homomorphic password(s) keyed by mdtoken, supporting multiple passwords per method with optional 1-based ordering. Formats: mdtoken:order:type:value | mdtoken:type:value. Types: sbyte, byte, short, ushort, int, uint, long, ulong, string. String values must be wrapped in double quotes (\"...\") and may contain colons; escape double quotes and backslashes with a backslash. Strings use UTF-16. Repeatable; passwords are consumed in the specified order per method.")
         {
             Arity = ArgumentArity.ZeroOrMore
         };
+
+        hmPasswordsOption.AddValidator(result =>
+        {
+            var entries = result.GetValueForOption(hmPasswordsOption) ?? Array.Empty<string>();
+            var errors = new List<string>();
+            foreach (var entry in entries)
+            {
+                if (string.IsNullOrWhiteSpace(entry))
+                {
+                    errors.Add("--hm-pass: empty specification provided");
+                    continue;
+                }
+
+                var parts = entry.Split(':', 4, StringSplitOptions.TrimEntries);
+                if (parts.Length < 2)
+                {
+                    errors.Add($"--hm-pass '{entry}': invalid format. Expected 'mdtoken:type:value' or 'mdtoken:order:type:value'.");
+                    continue;
+                }
+
+                var tokenStr = parts[0];
+                if (!TryParseMdTokenLocal(tokenStr, out _))
+                {
+                    errors.Add($"--hm-pass '{entry}': invalid mdtoken '{tokenStr}'. Use hex with or without 0x, e.g. 0x060000AB.");
+                    continue;
+                }
+
+                // Determine whether parts[1] is order or type, and compute value span accordingly.
+                string normType;
+                int valueStartIndex;
+                if (TryParseOrderLocal(parts[1], out _))
+                {
+                    // Expect at least 4 parts: mdtoken:order:type:value
+                    if (parts.Length < 4)
+                    {
+                        errors.Add($"--hm-pass '{entry}': invalid format. Expected 'mdtoken:order:type:value'.");
+                        continue;
+                    }
+                    if (!TryNormalizeTypeLocal(parts[2], out normType))
+                    {
+                        errors.Add($"--hm-pass '{entry}': unknown type '{parts[2]}'.");
+                        continue;
+                    }
+                    valueStartIndex = 3;
+                }
+                else if (TryNormalizeTypeLocal(parts[1], out normType))
+                {
+                    // Typed-only: mdtoken:type:value
+                    if (parts.Length < 3)
+                    {
+                        errors.Add($"--hm-pass '{entry}': invalid format. Expected 'mdtoken:type:value'.");
+                        continue;
+                    }
+                    valueStartIndex = 2;
+                }
+                else
+                {
+                    errors.Add($"--hm-pass '{entry}': invalid format. Expected 'mdtoken:type:value' or 'mdtoken:order:type:value'.");
+                    continue;
+                }
+
+                var valueJoined = string.Join(":", parts, valueStartIndex, parts.Length - valueStartIndex);
+                if (!TryValidateValueForTypeLocal(normType, valueJoined))
+                {
+                    errors.Add($"--hm-pass '{entry}': value '{valueJoined}' is not valid for type '{normType}'.");
+                    continue;
+                }
+            }
+
+            if (errors.Count > 0)
+                result.ErrorMessage =
+                    "Invalid --hm-pass specification(s):\n" +
+                    string.Join(Environment.NewLine, errors) +
+                    "\nAccepted formats: mdtoken:order:type:value | mdtoken:type:value";
+
+            static bool TryParseMdTokenLocal(string s, out uint token)
+            {
+                token = 0;
+                if (string.IsNullOrWhiteSpace(s)) return false;
+                s = s.Trim();
+                if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                    s = s[2..];
+                return uint.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out token);
+            }
+
+            static bool TryParseOrderLocal(string s, out int order)
+            {
+                order = 0;
+                if (string.IsNullOrWhiteSpace(s)) return false;
+                if (!int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var o)) return false;
+                if (o <= 0) return false;
+                order = o; return true;
+            }
+
+            static bool TryNormalizeTypeLocal(string s, out string norm)
+            {
+                norm = string.Empty;
+                if (string.IsNullOrWhiteSpace(s)) return false;
+                switch (s.Trim().ToLowerInvariant())
+                {
+                    case "sbyte": case "i8": norm = "sbyte"; return true;
+                    case "byte": case "u8": norm = "byte"; return true;
+                    case "short": case "int16": case "i16": norm = "int16"; return true;
+                    case "ushort": case "uint16": case "u16": norm = "uint16"; return true;
+                    case "int": case "int32": case "i32": norm = "int32"; return true;
+                    case "uint": case "uint32": case "u32": norm = "uint32"; return true;
+                    case "long": case "int64": case "i64": norm = "int64"; return true;
+                    case "ulong": case "uint64": case "u64": norm = "uint64"; return true;
+                    case "string": case "str": norm = "string"; return true;
+                    default: return false;
+                }
+            }
+
+            static bool TryValidateValueForTypeLocal(string type, string value)
+            {
+                if (type == "string")
+                {
+                    // Must be wrapped in double quotes so colons can be included safely.
+                    if (string.IsNullOrEmpty(value) || value.Length < 2) return false;
+                    if (!(value[0] == '"' && value[^1] == '"')) return false;
+                    // Validate escapes inside string: only allow \" and \\
+                    for (int i = 1; i < value.Length - 1; i++)
+                    {
+                        if (value[i] == '\\')
+                        {
+                            if (i + 1 >= value.Length - 1) return false; // trailing backslash
+                            var n = value[i + 1];
+                            if (n == '"' || n == '\\')
+                            { i++; continue; }
+                            return false; // disallow other escapes (e.g., \' or \n)
+                        }
+                    }
+                    return true;
+                }
+                if (string.IsNullOrWhiteSpace(value)) return false;
+                var s = value.Trim();
+                if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                {
+                    // For hex we accept any size and rely on unchecked casts in binder
+                    return ulong.TryParse(s[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _);
+                }
+                return type switch
+                {
+                    "sbyte" => sbyte.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+                    "byte" => byte.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+                    "int16" => short.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+                    "uint16" => ushort.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+                    "int32" => int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+                    "uint32" => uint.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+                    "int64" => long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+                    "uint64" => ulong.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+                    _ => false
+                };
+            }
+        });
         
         var rootCommand = new RootCommand("is an open-source tool that automatically restores the original IL code " +
                                           "from an assembly virtualized with Eazfuscator.NET")


### PR DESCRIPTION
Adds basic support for Eazfuscator's Homomorphic Encryption feature.

You must know the password to decrypt the encrypted code blocks. It is not feasible to quickly bruteforce keys over 5 bytes.

It should be noted this doesn't support passwords of the types `byte[]` and `IEnumerable<>`
Feel free to make a PR for them if you need them