### PR TITLE
Update to support 2025.3 and fix Resolver

### DIFF
--- a/.run/EazyDevirt -_ EazSample-eazfix.run.xml
+++ b/.run/EazyDevirt -_ EazSample-eazfix.run.xml
@@ -2,17 +2,20 @@
   <configuration default="false" name="EazyDevirt -&gt; EazSample-eazfix" type="DotNetProject" factoryName=".NET Project">
     <option name="EXE_PATH" value="$PROJECT_DIR$/src/EazyDevirt/bin/Debug/net6.0/EazyDevirt.exe" />
     <option name="PROGRAM_PARAMETERS" value="$PROJECT_DIR$/samples/EazSample/EazSample-eazfix.dll -v 3 -kt --preserve-all --save-anyway true --only-save-devirted false" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/EazyDevirt/bin/Debug/net6.0" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/EazyDevirt/bin/Debug/net10.0" />
     <option name="PASS_PARENT_ENVS" value="1" />
-    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="ENV_FILE_PATHS" value="" />
+    <option name="REDIRECT_INPUT_PATH" value="" />
+    <option name="MIXED_MODE_DEBUG" value="0" />
     <option name="USE_MONO" value="0" />
     <option name="RUNTIME_ARGUMENTS" value="" />
+    <option name="AUTO_ATTACH_CHILDREN" value="0" />
     <option name="PROJECT_PATH" value="$PROJECT_DIR$/src/EazyDevirt/EazyDevirt.csproj" />
     <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net6.0" />
+    <option name="PROJECT_TFM" value="net10.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/src/EazSample/EazSample.csproj
+++ b/src/EazSample/EazSample.csproj
@@ -4,10 +4,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+        <LangVersion>14</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EazyDevirt/Core/Architecture/InlineOperands/VMInlineOperand.cs
+++ b/src/EazyDevirt/Core/Architecture/InlineOperands/VMInlineOperand.cs
@@ -27,9 +27,9 @@ internal enum ValueType
 /// </remarks>
 internal enum VMInlineOperandType
 {
-    Type = 0,
+    Type = 2,
     Field = 1,
-    Method = 2,
+    Method = 0,
     EazCall = 3,
     UserString = 4
 }

--- a/src/EazyDevirt/Core/Architecture/VMExceptionHandler.cs
+++ b/src/EazyDevirt/Core/Architecture/VMExceptionHandler.cs
@@ -18,9 +18,9 @@ internal record VMExceptionHandler
             return VMHandlerType switch
             {
                 0 => CilExceptionHandlerType.Exception,
-                1 => CilExceptionHandlerType.Finally,
-                // 4 =>  CilExceptionHandlerType.Fault,
-                2 => CilExceptionHandlerType.Filter,
+                2 => CilExceptionHandlerType.Finally,
+                // 1 =>  CilExceptionHandlerType.Fault,
+                4 => CilExceptionHandlerType.Filter,
                 _ => throw new NotSupportedException()
             };
         }
@@ -32,8 +32,8 @@ internal record VMExceptionHandler
         CatchType = reader.ReadInt32();
         HandlerStart = reader.ReadUInt32();
         TryStart = reader.ReadUInt32();
-        FilterStart = reader.ReadUInt32();
         TryLength = reader.ReadUInt32();
+        FilterStart = reader.ReadUInt32();
     }
 
     public override string ToString() =>

--- a/src/EazyDevirt/Core/Architecture/VMMethod.cs
+++ b/src/EazyDevirt/Core/Architecture/VMMethod.cs
@@ -38,8 +38,8 @@ internal record VMMethodInfo
     public string Name { get; }
     public byte BindingFlags { get; }
     public bool IsStatic => (BindingFlags & 2) > 0;
-    public bool IsSecurityCritical => (BindingFlags & 4) > 0;
-    public bool IsUnknownFlag2 => (BindingFlags & 8) > 0;
+    public bool IsSecurityCritical => (BindingFlags & 1) > 0;
+    public bool IsUnknownFlag2 => (BindingFlags & 4) > 0;
     public int VMReturnType { get; }
     public List<VMLocal> VMLocals { get; }
     public List<VMParameter> VMParameters { get; }
@@ -49,18 +49,18 @@ internal record VMMethodInfo
     
     public VMMethodInfo(BinaryReader reader)
     {
-        VMDeclaringType = reader.ReadInt32();
-        Name = reader.ReadString();
-        BindingFlags = reader.ReadByte();
-        VMReturnType = reader.ReadInt32();
-
+        VMParameters = new List<VMParameter>(reader.ReadInt16());
+        for (var i = 0; i < VMParameters.Capacity; i++)
+            VMParameters.Add(new VMParameter(reader.ReadInt32(), reader.ReadBoolean()));
+        
         VMLocals = new List<VMLocal>(reader.ReadInt16());
         for (var i = 0; i < VMLocals.Capacity; i++)
             VMLocals.Add(new VMLocal(reader.ReadInt32()));
         
-        VMParameters = new List<VMParameter>(reader.ReadInt16());
-        for (var i = 0; i < VMParameters.Capacity; i++)
-            VMParameters.Add(new VMParameter(reader.ReadInt32(), reader.ReadBoolean()));
+        VMReturnType = reader.ReadInt32();
+        BindingFlags = reader.ReadByte();
+        VMDeclaringType = reader.ReadInt32();
+        Name = reader.ReadString();
     }
 
     public override string ToString() =>

--- a/src/EazyDevirt/Core/Architecture/VMOpCode.cs
+++ b/src/EazyDevirt/Core/Architecture/VMOpCode.cs
@@ -37,19 +37,19 @@ internal record VMOpCode(SerializedFieldDefinition SerializedInstructionField = 
         {
             return VirtualOperandType switch
             {
-                5 => CilOperandType.InlineI,
-                6 => CilOperandType.ShortInlineI,
-                8 => CilOperandType.InlineI8,
-                12 => CilOperandType.InlineR,
-                3 => CilOperandType.ShortInlineR,
-                2 => CilOperandType.InlineVar,              // used for both locals and arguments
-                4 => CilOperandType.ShortInlineVar,         // used for both locals and arguments
-                0 => CilOperandType.InlineTok,
-                1 => CilOperandType.InlineSwitch,
-                10 => CilOperandType.InlineBrTarget,        // in eazfuscator, this is unsigned
-                11 => CilOperandType.InlineArgument,        // this doesn't seem to be used, might not be correct 
-                7 => CilOperandType.ShortInlineArgument,    // this doesn't seem to be used, might not be correct
-                9 => CilOperandType.InlineNone,
+                6 => CilOperandType.InlineI, // 5
+                0 => CilOperandType.ShortInlineI, // 6
+                10 => CilOperandType.InlineI8, // 8
+                8 => CilOperandType.InlineR, // 12
+                4 => CilOperandType.ShortInlineR, //3 
+                5 => CilOperandType.InlineVar,        // 2      // used for both locals and arguments
+                3 => CilOperandType.ShortInlineVar,   // 4      // used for both locals and arguments
+                2 => CilOperandType.InlineTok,  //0
+                9 => CilOperandType.InlineSwitch, //1
+                1 => CilOperandType.InlineBrTarget, //10       // in eazfuscator, this is unsigned
+                12 => CilOperandType.InlineArgument, //11        // this doesn't seem to be used, might not be correct 
+                7 => CilOperandType.ShortInlineArgument,//7    // this doesn't seem to be used, might not be correct
+                11 => CilOperandType.InlineNone, // 9
 
                 _ => throw new ArgumentOutOfRangeException(nameof(VirtualOperandType), VirtualOperandType, "Unknown operand type")
             };

--- a/src/EazyDevirt/Core/IO/Resolver.cs
+++ b/src/EazyDevirt/Core/IO/Resolver.cs
@@ -4,6 +4,7 @@ using AsmResolver.DotNet.Signatures.Parsing;
 using EazyDevirt.Core.Architecture;
 using EazyDevirt.Core.Architecture.InlineOperands;
 using EazyDevirt.Devirtualization;
+using EazyDevirt.Util;
 
 namespace EazyDevirt.Core.IO;
 
@@ -14,6 +15,7 @@ internal class Resolver
         Ctx = ctx;
         VMStreamReader = new VMBinaryReader(new CryptoStreamV3(Ctx.VMResolverStream, Ctx.MethodCryptoKey, true));
         Cache = new Dictionary<int, object?>();
+        TypeSigVisitor = new TypeSigVisitor(Ctx.Module.Assembly!);
     }
     
     private DevirtualizationContext Ctx { get; }
@@ -21,6 +23,8 @@ internal class Resolver
     private VMBinaryReader VMStreamReader { get; }
     
     private Dictionary<int, object?> Cache { get; }
+    
+    private TypeSigVisitor TypeSigVisitor { get; }
 
     public ITypeDefOrRef? ResolveType(VMInlineOperand inlineOperand)
     {
@@ -68,21 +72,12 @@ internal class Resolver
         if (typeSig is null)
             throw new Exception($"Failed to parse vm type {data.Name}");
 
+        typeSig.AcceptVisitor(TypeSigVisitor);
+        
         if (data.HasGenericTypeParameters)
             typeSig = typeSig.MakeGenericInstanceType(data.GenericParameters.Select(x => ResolveType(x)!.ToTypeSignature()).ToArray());
 
         var typeDefOrRef = typeSig.ToTypeDefOrRef();
-        if (SignatureComparer.Default.Equals(typeDefOrRef.Scope?.GetAssembly(), Ctx.Module.Assembly))
-        {
-            var resolvedType = typeDefOrRef.Resolve();
-            if (resolvedType is not null)
-                typeDefOrRef = resolvedType;
-            else
-                Ctx.Console.Warning($"Failed to resolve same assembly vm type {data.Name}, using its reference instead.");
-        }
-        else
-            typeDefOrRef = Ctx.Importer.ImportType(typeDefOrRef);
-        
         Cache.Add(position, typeDefOrRef);
         return typeDefOrRef;
     }
@@ -115,7 +110,7 @@ internal class Resolver
 
         if (declaringType.Resolve() is { } declaringTypeDef)
         {
-            var fieldDef = declaringTypeDef.Fields.FirstOrDefault(f => f.Name == data.Name && f.IsStatic == data.IsStatic)?.ImportWith(Ctx.Importer);
+            var fieldDef = declaringTypeDef.Fields.FirstOrDefault(f => f.Name == data.Name && f.IsStatic == data.IsStatic);
             Cache.Add(position, fieldDef);
             return fieldDef;
         }
@@ -210,8 +205,19 @@ internal class Resolver
             Ctx.Console.Error($"Failed to resolve generic method {name}!");
             return null;
         }
-        
-        return declaringTypeDefOrRef.CreateMemberReference(name, vmMethodSig);
+
+        IMethodDescriptor memberRef = declaringTypeDefOrRef.CreateMemberReference(name, vmMethodSig);
+        var scope = declaringTypeDefOrRef.Scope?.GetAssembly();
+        if (vmGenericContext.IsEmpty && SignatureComparer.Default.Equals(scope, Ctx.Module.Assembly))
+        {
+            var methodDef = memberRef.Resolve();
+            if (methodDef is not null) 
+                return methodDef;
+            
+            Ctx.Console.Warning($"Failed to resolve method {memberRef.FullName} to methoddef! Placing member reference instead.");
+        }
+
+        return memberRef;
     }
     
     public IMethodDescriptor? ResolveMethod(int position)
@@ -260,12 +266,12 @@ internal class Resolver
                     vmGenericContext.Method?.TypeArguments.Count ?? 0, vmParameters))
             .InstantiateGenericTypes(vmGenericContext);
         
-        var method = ResolveMethod(data.Name, declaringTypeDefOrRef, vmMethodSig, vmParameters, vmGenericContext)?.ImportWith(Ctx.Importer);
+        var method = ResolveMethod(data.Name, declaringTypeDefOrRef, vmMethodSig, vmParameters, vmGenericContext);
         if (method is null) 
             return null;
         
         Cache.Add(position, method);
-        return (IMethodDescriptor)method;
+        return method;
     }
 
     public IMemberDescriptor? ResolveToken(int position)
@@ -371,7 +377,23 @@ internal class Resolver
             return null;
         }
         
-        var vmParameters = methodInfo.VMParameters.Select(x => ResolveType(x.VMType)?.ToTypeSignature()!).ToArray();
+        var vmParameters = new TypeSignature[methodInfo.VMParameters.Count];
+        for (var index = 0; index < methodInfo.VMParameters.Count; index++)
+        {
+            var vmParameter = methodInfo.VMParameters[index];
+            var typeSig = ResolveType(vmParameter.VMType)?.ToTypeSignature();
+            if (typeSig is null)
+            {
+                Ctx.Console.Error($"Failed to resolve eaz call {methodInfo.Name} parameter {index}!");
+                return null;
+            }
+            
+            if (vmParameter.In && typeSig is not ByReferenceTypeSignature)
+                Ctx.Console.Warning($"Parameter {index} of eaz call {methodInfo.Name} has In flag set but is not a by reference type!");
+            
+            vmParameters[index] = typeSig;
+        }
+
 
         var vmMethodSig = (methodInfo.IsStatic
                 ? MethodSignature.CreateStatic(returnType.ToTypeSignature(),
@@ -386,6 +408,9 @@ internal class Resolver
             Ctx.Console.Error($"Failed to resolve eaz call {methodInfo.Name}!");
             return null;
         }
+
+        if (method is not MethodDefinition or MethodSpecification { Method: MethodDefinition })
+            Ctx.Console.Warning($"Eaz call {methodInfo.Name} failed to resolve to a method definition, is the method missing? Placing reference instead.");
 
         Cache.Add(position, method);
         return method;

--- a/src/EazyDevirt/Devirtualization/Pipeline/OpCodeMapping.cs
+++ b/src/EazyDevirt/Devirtualization/Pipeline/OpCodeMapping.cs
@@ -109,7 +109,7 @@ internal class OpCodeMapping : StageBase
         {
             var instructionField = op[2].Operand as SerializedFieldDefinition;
             var instructionField2 = op[7].Operand as SerializedFieldDefinition;
-            var opCodeDelegate = op[9].Operand as SerializedMethodDefinition;
+            var opCodeDelegate = op[13].Operand as SerializedMethodDefinition;
             // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
             containerType ??= instructionField!.DeclaringType!;
             

--- a/src/EazyDevirt/Devirtualization/Pipeline/OpCodeMapping.cs
+++ b/src/EazyDevirt/Devirtualization/Pipeline/OpCodeMapping.cs
@@ -193,7 +193,10 @@ internal class OpCodeMapping : StageBase
         
         if (Ctx.Options.VeryVerbose)
             Ctx.Console.InfoStr($"VM opcodes identified ({identified / vmOpCodes.Count:P})", identified);
-                
+
+        if (Ctx.Options.VeryVeryVerbose)
+                Ctx.Console.InfoStr($"Unidentified opcode patterns: {string.Join(", ", Ctx.PatternMatcher.OpCodePatterns.Select(x => x.IsSpecial ? x.SpecialOpCode.ToString() : x.CilOpCode.ToString()))}", Ctx.PatternMatcher.OpCodePatterns.Count);
+
         return true;
     }
 

--- a/src/EazyDevirt/Devirtualization/Pipeline/OpCodeMapping.cs
+++ b/src/EazyDevirt/Devirtualization/Pipeline/OpCodeMapping.cs
@@ -195,7 +195,10 @@ internal class OpCodeMapping : StageBase
             Ctx.Console.InfoStr($"VM opcodes identified ({identified / vmOpCodes.Count:P})", identified);
 
         if (Ctx.Options.VeryVeryVerbose)
-                Ctx.Console.InfoStr($"Unidentified opcode patterns: {string.Join(", ", Ctx.PatternMatcher.OpCodePatterns.Select(x => x.IsSpecial ? x.SpecialOpCode.ToString() : x.CilOpCode.ToString()))}", Ctx.PatternMatcher.OpCodePatterns.Count);
+        {
+            var unidentifiedPatterns = Ctx.PatternMatcher.OpCodePatterns.Where(x => !x.AllowMultiple).ToList();
+            Ctx.Console.InfoStr($"Unidentified opcode patterns (excluding AllowMultiple): {string.Join(", ", unidentifiedPatterns.Select(x => x.IsSpecial ? x.SpecialOpCode.ToString() : x.CilOpCode.ToString()))}", unidentifiedPatterns.Count);
+        }
 
         return true;
     }

--- a/src/EazyDevirt/Devirtualization/Pipeline/ResourceParsing.cs
+++ b/src/EazyDevirt/Devirtualization/Pipeline/ResourceParsing.cs
@@ -124,7 +124,9 @@ internal sealed class ResourceParsing : StageBase
     {
         foreach (var type in Ctx.Module.GetAllTypes())
         {
-            if (_resourceGetterMethod != null && _resourceInitializationMethod != null) return true;
+            if (_resourceGetterMethod != null && _resourceInitializationMethod != null)
+                return true;
+            
             foreach (var method in type.Methods.Where(m =>
                          m is { Managed: true, IsPublic: true, IsStatic: true } &&
                          m.Signature?.ReturnType.FullName == typeof(Stream).FullName))
@@ -140,7 +142,8 @@ internal sealed class ResourceParsing : StageBase
                     (SerializedMethodDefinition)method.CilMethodBody!.Instructions[12].Operand!;
                 var getVmInstanceMethod = type.Methods.First(m =>
                     m.MetadataToken != _resourceGetterMethod.MetadataToken &&
-                    m.MetadataToken != _resourceModulusStringMethod.MetadataToken);
+                    m.MetadataToken != _resourceModulusStringMethod.MetadataToken
+                    && m is { IsAssembly: false, Parameters.Count: 0 });
 
                 if (!getVmInstanceMethod.Signature!.ReturnsValue)
                     throw new Exception("Failed to get VM Declaring type!");

--- a/src/EazyDevirt/EazyDevirt.csproj
+++ b/src/EazyDevirt/EazyDevirt.csproj
@@ -2,10 +2,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+        <LangVersion>14</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EazyDevirt/EazyDevirt.csproj
+++ b/src/EazyDevirt/EazyDevirt.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.4" />
+      <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.5" />
       <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>

--- a/src/EazyDevirt/PatternMatching/PatternMatcher.cs
+++ b/src/EazyDevirt/PatternMatching/PatternMatcher.cs
@@ -20,11 +20,12 @@ internal class PatternMatcher
     }
     
     private Dictionary<int, VMOpCode> OpCodes { get; }
-    private List<IOpCodePattern> OpCodePatterns { get; }
+    public List<IOpCodePattern> OpCodePatterns { get; }
     
     public void SetOpCodeValue(int value, VMOpCode opCode) => OpCodes[value] = opCode;
 
     public VMOpCode GetOpCodeValue(int value) => OpCodes.TryGetValue(value, out var opc) ? opc : VMOpCode.DefaultNopOpCode;
+
 
     public IOpCodePattern FindOpCode(VMOpCode vmOpCode, int index = 0)
     {

--- a/src/EazyDevirt/PatternMatching/Patterns/OpCodeDictionaryAddPattern.cs
+++ b/src/EazyDevirt/PatternMatching/Patterns/OpCodeDictionaryAddPattern.cs
@@ -11,19 +11,25 @@ internal record OpCodeDictionaryAddPattern : IPattern
     /// </summary>
     public IList<CilOpCode> Pattern => new List<CilOpCode>
     {
-        CilOpCodes.Dup,         // 2	000A	dup
-        CilOpCodes.Ldarg_0,     // 3	000B	ldarg.0
-        CilOpCodes.Ldfld,       // 4	000C	ldfld	valuetype VMOpCode VMOpCodeStructs::struct4_171
-        CilOpCodes.Stloc_0,     // 5	0011	stloc.0
-        CilOpCodes.Ldloca_S,    // 6	0012	ldloca.s	V_0 (0)
-        CilOpCodes.Call,        // 7	0014	call	instance int32 VMOpCode::GetVMOpCodeType()
-        CilOpCodes.Ldarg_0,     // 8	0019	ldarg.0
-        CilOpCodes.Ldfld,       // 9	001A	ldfld	valuetype VMOpCode VMOpCodeStructs::struct4_171
-        CilOpCodes.Ldnull,      // 10	001F	ldnull
-        CilOpCodes.Ldftn,       // 11	0020	ldftn	void VM::smethod_121(class VM, class VMTypeAndVal)
-        CilOpCodes.Newobj,      // 12	0026	newobj	instance void VM/Delegate21::.ctor(object, native int)
-        CilOpCodes.Newobj,      // 13	002B	newobj	instance void VM/VMOperand::.ctor(valuetype VMOpCode, class VM/Delegate21)
-        CilOpCodes.Callvirt,    // 14	0030	callvirt	instance void class [mscorlib]System.Collections.Generic.Dictionary`2<int32, valuetype VM/VMOperand>::Add(!0, !1)
+        CilOpCodes.Dup,         // 40    007E   dup
+        CilOpCodes.Ldarg_0,     // 41    007F   ldarg.0
+        CilOpCodes.Ldfld,       // 42    0080   ldfld   valuetype Struct13 VMOpCodeStructs::struct13_89
+        CilOpCodes.Stloc_0,     // 43    0085   stloc.0
+        CilOpCodes.Ldloca_S,    // 44    0086   ldloca.s   V_0 (0)
+        CilOpCodes.Call,        // 45    0088   call   instance int32 Struct13::GetVMOpCodeType()
+        CilOpCodes.Ldarg_0,     // 46    008D   ldarg.0
+        CilOpCodes.Ldfld,       // 47    008E   ldfld   valuetype Struct13 VMOpCodeStructs::struct13_89
+        CilOpCodes.Ldsfld,      // 48    0093   ldsfld  class VM/VMOpCodeDelegate VM/VMOpCodeDelegateStorage::delegate1_25
+        CilOpCodes.Dup,         // 49    0098   dup
+        CilOpCodes.Brtrue_S,    // 50    0099   brtrue.s   57 (00AE) newobj instance void VM/VMOperand::.ctor(valuetype Struct13, class VM/VMOpCodeDelegate)
+        CilOpCodes.Pop,         // 51    009B   pop
+        CilOpCodes.Ldnull,      // 52    009C   ldnull
+        CilOpCodes.Ldftn,       // 53    009D   ldftn   void VM::smethod_27(class VM, class Class81)
+        CilOpCodes.Newobj,      // 54    00A3   newobj  instance void VM/VMOpCodeDelegate::.ctor(object, native int)
+        CilOpCodes.Dup,         // 55    00A8   dup
+        CilOpCodes.Stsfld,      // 56    00A9   stsfld  class VM/VMOpCodeDelegate VM/VMOpCodeDelegateStorage::delegate1_25
+        CilOpCodes.Newobj,      // 57    00AE   newobj  instance void VM/VMOperand::.ctor(valuetype Struct13, class VM/VMOpCodeDelegate)
+        CilOpCodes.Callvirt,    // 58    00B3   callvirt   instance void class [System.Collections]System.Collections.Generic.Dictionary`2<int32, valuetype VM/VMOperand>::Add(!0, !1)
                                 // ...
     };
     

--- a/src/EazyDevirt/PatternMatching/Patterns/OpCodes/Call.cs
+++ b/src/EazyDevirt/PatternMatching/Patterns/OpCodes/Call.cs
@@ -132,7 +132,6 @@ internal record CallvirtInnerPattern : IPattern
         CilOpCodes.Stloc_0,     // 7	0015	stloc.0
         CilOpCodes.Ldarg_0,     // 8	0016	ldarg.0
         CilOpCodes.Ldfld,       // 9	0017	ldfld	class [mscorlib]System.Type VM::type_2
-        CilOpCodes.Brfalse_S,   // 10	001C	brfalse.s	63 (0081) ldarg.0
     };
 
     public bool MatchEntireBody => false;

--- a/src/EazyDevirt/PatternMatching/Patterns/OpCodes/Comparators.cs
+++ b/src/EazyDevirt/PatternMatching/Patterns/OpCodes/Comparators.cs
@@ -31,11 +31,11 @@ internal record Clt : IOpCodePattern
 {
     public IList<CilOpCode> Pattern => new List<CilOpCode>
     {
-        CilOpCodes.Call,        // 9	0011	call	bool VM::Clt_Inner(class VMOperandType, class VMOperandType)
-        CilOpCodes.Brtrue_S,    // 10	0016	brtrue.s	13 (001B) ldc.i4.1 
-        CilOpCodes.Ldc_I4_0,    // 11	0018	ldc.i4.0
-        CilOpCodes.Br_S,        // 12	0019	br.s	14 (001C) newobj instance void VMIntOperand::.ctor(int32)
-        CilOpCodes.Ldc_I4_1,    // 13	001B	ldc.i4.1
+        CilOpCodes.Call,        // 9    0011   call   bool VM::Clt_Inner(class VMOperandType, class VMOperandType)
+        CilOpCodes.Ldc_I4_0,    // 10   0016   ldc.i4.0
+        CilOpCodes.Cgt_Un,      // 11   0017   cgt.un
+        CilOpCodes.Newobj,      // 12   0019   newobj instance void VMIntOperand::.ctor(int32)
+        CilOpCodes.Callvirt,    // 13   001E   callvirt   instance void VM::PushStack(class VMOperandType)
     };
 
     public CilOpCode? CilOpCode => CilOpCodes.Clt;
@@ -73,11 +73,11 @@ internal record Clt_Un : IOpCodePattern
 {
     public IList<CilOpCode> Pattern => new List<CilOpCode>
     {
-        CilOpCodes.Call,        // 9	0011	call	bool VM::Clt_UnInner(class VMOperandType, class VMOperandType)
-        CilOpCodes.Brtrue_S,    // 10	0016	brtrue.s	13 (001B) ldc.i4.1 
-        CilOpCodes.Ldc_I4_0,    // 11	0018	ldc.i4.0
-        CilOpCodes.Br_S,        // 12	0019	br.s	14 (001C) newobj instance void VMIntOperand::.ctor(int32)
-        CilOpCodes.Ldc_I4_1,    // 13	001B	ldc.i4.1
+        CilOpCodes.Call,        // 9    0011   call   bool VM::Clt_UnInner(class VMOperandType, class VMOperandType)
+        CilOpCodes.Ldc_I4_0,    // 10   0016   ldc.i4.0
+        CilOpCodes.Cgt_Un,      // 11   0017   cgt.un
+        CilOpCodes.Newobj,      // 12   0019   newobj instance void VMIntOperand::.ctor(int32)
+        CilOpCodes.Callvirt,    // 13   001E   callvirt   instance void VM::PushStack(class VMOperandType)
     };
 
     public CilOpCode? CilOpCode => CilOpCodes.Clt_Un;
@@ -114,11 +114,11 @@ internal record Cgt : IOpCodePattern
 {
     public IList<CilOpCode> Pattern => new List<CilOpCode>
     {
-        CilOpCodes.Call,        // 9	0011	call	bool VM::CgtInner(class VMOperandType, class VMOperandType)
-        CilOpCodes.Brtrue_S,    // 10	0016	brtrue.s	13 (001B) ldc.i4.1 
-        CilOpCodes.Ldc_I4_0,    // 11	0018	ldc.i4.0
-        CilOpCodes.Br_S,        // 12	0019	br.s	14 (001C) newobj instance void VMIntOperand::.ctor(int32)
-        CilOpCodes.Ldc_I4_1,    // 13	001B	ldc.i4.1
+        CilOpCodes.Call,        // 9    0011   call   bool VM::Cgt_Inner(class VMOperandType, class VMOperandType)
+        CilOpCodes.Ldc_I4_0,    // 10   0016   ldc.i4.0
+        CilOpCodes.Cgt_Un,      // 11   0017   cgt.un
+        CilOpCodes.Newobj,      // 12   0019   newobj instance void VMIntOperand::.ctor(int32)
+        CilOpCodes.Callvirt,    // 13   001E   callvirt   instance void VM::PushStack(class VMOperandType)
     };
 
     public CilOpCode? CilOpCode => CilOpCodes.Cgt;
@@ -157,11 +157,11 @@ internal record Cgt_Un : IOpCodePattern
 {
     public IList<CilOpCode> Pattern => new List<CilOpCode>
     {
-        CilOpCodes.Call,        // 9	0011	call	bool VM::Cgt_UnInner(class VMOperandType, class VMOperandType)
-        CilOpCodes.Brtrue_S,    // 10	0016	brtrue.s	13 (001B) ldc.i4.1 
-        CilOpCodes.Ldc_I4_0,    // 11	0018	ldc.i4.0
-        CilOpCodes.Br_S,        // 12	0019	br.s	14 (001C) newobj instance void VMIntOperand::.ctor(int32)
-        CilOpCodes.Ldc_I4_1,    // 13	001B	ldc.i4.1
+        CilOpCodes.Call,        // 9    0011   call   bool VM::Cgt_UnInner(class VMOperandType, class VMOperandType)
+        CilOpCodes.Ldc_I4_0,    // 10   0016   ldc.i4.0
+        CilOpCodes.Cgt_Un,      // 11   0017   cgt.un
+        CilOpCodes.Newobj,      // 12   0019   newobj instance void VMIntOperand::.ctor(int32)
+        CilOpCodes.Callvirt,    // 13   001E   callvirt   instance void VM::PushStack(class VMOperandType)
     };
 
     public CilOpCode? CilOpCode => CilOpCodes.Cgt_Un;
@@ -203,11 +203,11 @@ internal record Ceq : IOpCodePattern
 {
     public IList<CilOpCode> Pattern => new List<CilOpCode>
     {
-        CilOpCodes.Call,        // 11	0017	call	bool VM::CeqInner(class VMOperandType, class VMOperandType)
-        CilOpCodes.Brtrue_S,    // 12	001C	brtrue.s	15 (0021) ldc.i4.1 
-        CilOpCodes.Ldc_I4_0,    // 13	001E	ldc.i4.0
-        CilOpCodes.Br_S,        // 14	001F	br.s	16 (0022) callvirt instance void VMIntOperand::method_4(int32)
-        CilOpCodes.Ldc_I4_1,    // 15	0021	ldc.i4.1
+        CilOpCodes.Call,        // 11   0017   call   bool VM::CeqInner(class VMOperandType, class VMOperandType)
+        CilOpCodes.Ldc_I4_0,    // 12   001C   ldc.i4.0
+        CilOpCodes.Cgt_Un,      // 13   001D   cgt.un
+        CilOpCodes.Callvirt,    // 14   001F   callvirt   instance void VMIntOperand::method_4(int32)
+        CilOpCodes.Callvirt,    // 15   0024   callvirt   instance void VM::PushStack(class VMOperandType)
     };
 
     public CilOpCode? CilOpCode => CilOpCodes.Ceq;

--- a/src/EazyDevirt/PatternMatching/Patterns/OpCodes/Misc.cs
+++ b/src/EazyDevirt/PatternMatching/Patterns/OpCodes/Misc.cs
@@ -347,12 +347,13 @@ internal record IsVMOperandAssignableFromTypePattern : IPattern
 {
     public IList<CilOpCode> Pattern => new List<CilOpCode>
     {
-        CilOpCodes.Ldloc_1,         // 15	001D	ldloc.1
-        CilOpCodes.Ldarg_2,         // 16	001E	ldarg.2
-        CilOpCodes.Beq_S,           // 17	001F	beq.s	61 (007F) ldc.i4.1 
-        CilOpCodes.Ldarg_2,         // 18	0021	ldarg.2
-        CilOpCodes.Ldloc_1,         // 19	0022	ldloc.1
-        CilOpCodes.Callvirt,        // 20	0023	callvirt	instance bool [mscorlib]System.Type::IsAssignableFrom(class [mscorlib]System.Type)
+        CilOpCodes.Ldloc_1,     // 15   001D   ldloc.1
+        CilOpCodes.Ldarg_2,     // 16   001E   ldarg.2
+        CilOpCodes.Call,        // 17   001F   call       bool [System.Runtime]System.Type::op_Equality(class [System.Runtime]System.Type, class [System.Runtime]System.Type)
+        CilOpCodes.Brtrue_S,    // 18   0024   brtrue.s   62 (0084) ldc.i4.1 
+        CilOpCodes.Ldarg_2,     // 19   0026   ldarg.2
+        CilOpCodes.Ldloc_1,     // 20   0027   ldloc.1
+        CilOpCodes.Callvirt,    // 21   0028   callvirt   instance bool [System.Runtime]System.Type::IsAssignableFrom(class [System.Runtime]System.Type)
     };
 
     public bool MatchEntireBody => false;
@@ -360,7 +361,7 @@ internal record IsVMOperandAssignableFromTypePattern : IPattern
     public bool InterchangeLdlocOpCodes => true;
 
     public bool Verify(CilInstructionCollection instructions, int index = 0) =>
-        (instructions[index + 5].Operand as IMethodDescriptor)?.FullName ==
+        (instructions[index + 6].Operand as IMethodDescriptor)?.FullName ==
         "System.Boolean System.Type::IsAssignableFrom(System.Type)";
 }
 

--- a/src/EazyDevirt/PatternMatching/Patterns/PushStackPattern.cs
+++ b/src/EazyDevirt/PatternMatching/Patterns/PushStackPattern.cs
@@ -8,18 +8,18 @@ internal record PushStackPattern : IPattern
 {
     public IList<CilOpCode> Pattern => new List<CilOpCode>
     { 
-        CilOpCodes.Ldarg_1,     // 0	0000	ldarg.1
-        CilOpCodes.Brtrue_S,    // 1	0001	brtrue.s	6 (000F) ldarg.1 
-        CilOpCodes.Nop,         // 2	0003	nop
-        CilOpCodes.Ldstr,       // 3	0004	ldstr	"obj"
-        CilOpCodes.Newobj,      // 4	0009	newobj	instance void [mscorlib]System.ArgumentNullException::.ctor(string)
-        CilOpCodes.Throw,       // 5	000E	throw
-        CilOpCodes.Ldarg_1,     // 6	000F	ldarg.1
-        CilOpCodes.Callvirt,    // 7	0010	callvirt	instance class [mscorlib]System.Type VMOperandType::GetOperandType()
-        CilOpCodes.Brfalse_S,   // 8	0015	brfalse.s	12 (001E) ldarg.1 
-        CilOpCodes.Ldarg_1,     // 9	0017	ldarg.1
-        CilOpCodes.Stloc_0,     // 10	0018	stloc.0
-        CilOpCodes.Br,          // 11	0019	br	168 (0208) ldarg.0 
+        CilOpCodes.Ldarg_1,     // 0    0000   ldarg.1
+        CilOpCodes.Brtrue_S,    // 1    0001   brtrue.s   6 (000F) ldarg.1
+        CilOpCodes.Nop,         // 2    0003   nop
+        CilOpCodes.Ldstr,       // 3    0004   ldstr      "obj"
+        CilOpCodes.Newobj,      // 4    0009   newobj     instance void [System.Runtime]System.ArgumentNullException::.ctor(string)
+        CilOpCodes.Throw,       // 5    000E   throw
+        CilOpCodes.Ldarg_1,     // 6    000F   ldarg.1
+        CilOpCodes.Callvirt,    // 7    0010   callvirt   instance class [System.Runtime]System.Type '\u000e'::'\u0002'()
+        CilOpCodes.Ldnull,      // 8    0015   ldnull
+        CilOpCodes.Call,        // 9    0016   call       bool [System.Runtime]System.Type::op_Inequality(class [System.Runtime]System.Type, class [System.Runtime]System.Type)
+        CilOpCodes.Brfalse_S,   // 10   001B   brfalse.s  14 (0024) ldarg.1
+        CilOpCodes.Ldarg_1,     // 11   001D   ldarg.1
                                 // ...
     };
     

--- a/src/EazyDevirt/Program.cs
+++ b/src/EazyDevirt/Program.cs
@@ -18,8 +18,6 @@ internal static class Program
         var parser = BuildParser();
 
         await parser.InvokeAsync(args).ConfigureAwait(false);
-
-        Console.ReadLine();
     }
 
     private static void Run(DevirtualizationOptions options)

--- a/src/EazyDevirt/Program.cs
+++ b/src/EazyDevirt/Program.cs
@@ -10,8 +10,8 @@ namespace EazyDevirt;
 
 internal static class Program
 {
-    private static readonly Version CurrentVersion = new("1.0.0");
-    private static readonly Version CurrentEazVersion = new("2022.2.763.35371");
+    private static readonly Version CurrentVersion = new("2.0.0");
+    private static readonly Version CurrentEazVersion = new("2025.3.195.25680");
 
     private static async Task Main(params string[] args)
     {

--- a/src/EazyDevirt/Util/TypeSigVisitor.cs
+++ b/src/EazyDevirt/Util/TypeSigVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using EazyDevirt.Devirtualization;
 
 namespace EazyDevirt.Util;
 
@@ -42,7 +43,7 @@ public class TypeSigVisitor : ITypeSignatureVisitor<TypeSignature>
             if (signature.ModifierType.Resolve() is { } typeDef)
                 signature.ModifierType = typeDef;
             else
-                throw new Exception($"Failed to resolve CustomModifierTypeSignature {signature} to typedef.");
+                DevirtualizationContext.Instance.Console.Error($"Failed to resolve CustomModifierTypeSignature {signature} to typedef.");
         }
         
         signature.BaseType.AcceptVisitor(this);
@@ -56,7 +57,7 @@ public class TypeSigVisitor : ITypeSignatureVisitor<TypeSignature>
             if (signature.GenericType.Resolve() is { } typeDef)
                 signature.GenericType = typeDef;
             else
-                throw new Exception($"Failed to resolve GenericInstanceTypeSignature {signature} to typedef.");
+                DevirtualizationContext.Instance.Console.Error($"Failed to resolve GenericInstanceTypeSignature {signature} to typedef.");
         }
         
         foreach (var typeArgument in signature.TypeArguments)
@@ -103,7 +104,7 @@ public class TypeSigVisitor : ITypeSignatureVisitor<TypeSignature>
         if (signature.Type.Resolve() is { } typeDef)
             signature.Type = typeDef;
         else
-            throw new Exception($"Failed to resolve TypeDefOrRefSignature {signature} to typedef.");
+            DevirtualizationContext.Instance.Console.Error($"Failed to resolve TypeDefOrRefSignature {signature} to typedef.");
 
         return signature;
     }

--- a/src/EazyDevirt/Util/TypeSigVisitor.cs
+++ b/src/EazyDevirt/Util/TypeSigVisitor.cs
@@ -1,0 +1,110 @@
+﻿using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+
+namespace EazyDevirt.Util;
+
+public class TypeSigVisitor : ITypeSignatureVisitor<TypeSignature>
+{
+    private AssemblyDescriptor _assembly;
+    
+    public TypeSigVisitor(AssemblyDescriptor assembly)
+    {
+        _assembly = assembly;
+    }
+    
+    public TypeSignature VisitArrayType(ArrayTypeSignature signature)
+    {
+        signature.BaseType.AcceptVisitor(this);
+        return signature;
+    }
+
+    public TypeSignature VisitBoxedType(BoxedTypeSignature signature)
+    {
+        signature.BaseType.AcceptVisitor(this);
+        return signature;
+    }
+
+    public TypeSignature VisitByReferenceType(ByReferenceTypeSignature signature)
+    {
+        signature.BaseType.AcceptVisitor(this);
+        return signature;
+    }
+
+    public TypeSignature VisitCorLibType(CorLibTypeSignature signature)
+    {
+        return signature;
+    }
+
+    public TypeSignature VisitCustomModifierType(CustomModifierTypeSignature signature)
+    {
+        if (SignatureComparer.Default.Equals(signature.ModifierType.Scope?.GetAssembly(), _assembly))
+        {
+            if (signature.ModifierType.Resolve() is { } typeDef)
+                signature.ModifierType = typeDef;
+            else
+                throw new Exception($"Failed to resolve CustomModifierTypeSignature {signature} to typedef.");
+        }
+        
+        signature.BaseType.AcceptVisitor(this);
+        return signature;
+    }
+
+    public TypeSignature VisitGenericInstanceType(GenericInstanceTypeSignature signature)
+    {
+        if (SignatureComparer.Default.Equals(signature.GenericType.Scope?.GetAssembly(), _assembly))
+        {
+            if (signature.GenericType.Resolve() is { } typeDef)
+                signature.GenericType = typeDef;
+            else
+                throw new Exception($"Failed to resolve GenericInstanceTypeSignature {signature} to typedef.");
+        }
+        
+        foreach (var typeArgument in signature.TypeArguments)
+            typeArgument.AcceptVisitor(this);
+        
+        return signature;
+    }
+
+    public TypeSignature VisitGenericParameter(GenericParameterSignature signature)
+    {
+        return signature;
+    }
+
+    public TypeSignature VisitPinnedType(PinnedTypeSignature signature)
+    {
+        return new PinnedTypeSignature(signature.BaseType.AcceptVisitor(this));
+    }
+
+    public TypeSignature VisitPointerType(PointerTypeSignature signature)
+    {
+        return new PointerTypeSignature(signature.BaseType.AcceptVisitor(this));
+    }
+
+    public TypeSignature VisitSentinelType(SentinelTypeSignature signature)
+    {
+        return signature;
+    }
+
+    public TypeSignature VisitSzArrayType(SzArrayTypeSignature signature)
+    {
+        return new SzArrayTypeSignature(signature.BaseType.AcceptVisitor(this));
+    }
+
+    public TypeSignature VisitFunctionPointerType(FunctionPointerTypeSignature signature)
+    {
+        return signature;
+    }
+    
+    public TypeSignature VisitTypeDefOrRef(TypeDefOrRefSignature signature)
+    {
+        if (!SignatureComparer.Default.Equals(signature.Type.Scope?.GetAssembly(), _assembly)) 
+            return signature;
+        
+        if (signature.Type.Resolve() is { } typeDef)
+            signature.Type = typeDef;
+        else
+            throw new Exception($"Failed to resolve TypeDefOrRefSignature {signature} to typedef.");
+
+        return signature;
+    }
+}


### PR DESCRIPTION
This PR:
* Updates VM constants for 2025.3 (2025.3.195.25680)
* Fix opcode patterns, opcode dictionary mapping, and the resource parsing stage for 2025.3
* Update AsmResolver to 6.0.0-beta.5 to fix issues with MemberNotImportedException
* Target .NET 10 and C# 14
* Fix Resolver returning references instead of definitions where unnecessary to prevent unnecessary references and tool incompatibility (EazFixer)
  - TypeSigVisitor is used to resolve definitions while keeping the modifiers of the type signature without entirely rebuilding it
* Update version numbers
* Adds an info message to show unidentified opcode patterns (excluding AllowMultiple patterns like stind, NoBody, volatile)
* Removes the Console.ReadLine at end of execution so program can close